### PR TITLE
Use chroma.deltaE in color suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ import { isColorInPalette, getSuggestions } from 'svg-color-linter';
 isColorInPalette('#FFFFFF', ['#EEEEEE', '#121212']);
 // false
 
-getSuggestions('##C0CA35', ['#EEEEEE', '#121212']);
+getSuggestions('#C0CA35', ['#EEEEEE', '#121212']);
 // [
-//   { hex: '#C0CA33', distance: 0.6447550226954274 },
-//   { hex: '#CDDC39', distance: 8.143421457635025 },
-//   { hex: '#D4E157', distance: 9.090777903129522 },
-//   { hex: '#AFB42B', distance: 9.175451993395148 },
-//   { hex: '#DCE775', distance: 17.927826688923673 }
+//   { hex: '#C0CA33', distance: 0.160467661071053 },
+//   { hex: '#CDDC39', distance: 4.307076277707079 },
+//   { hex: '#D4E157', distance: 5.606714639567858 },
+//   { hex: '#AFB42B', distance: 5.713845679863578 },
+//   { hex: '#DCE775', distance: 8.065940911169271 }
 // ]
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "chroma-js": "^2.1.2",
+        "chroma-js": "^2.2.0",
         "glob": "^7.2.0",
         "is-glob": "^4.0.3",
         "is-svg": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "chroma-js": "^2.1.2",
+    "chroma-js": "^2.2.0",
     "glob": "^7.2.0",
     "is-glob": "^4.0.3",
     "is-svg": "^4.3.2",

--- a/src/core/suggestions.ts
+++ b/src/core/suggestions.ts
@@ -1,4 +1,4 @@
-import { distance } from 'chroma-js';
+import { deltaE } from 'chroma-js';
 import { ColorSuggestion } from './models';
 import { isValidColor, toHexColor } from './utils';
 
@@ -14,7 +14,7 @@ const getSuggestions = (
 
   const distances = palette
     .map((paletteColor) => ({
-      distance: distance(paletteColor, color),
+      distance: deltaE(paletteColor, color),
       color: paletteColor,
     }))
     .sort((a, b) => a.distance - b.distance);


### PR DESCRIPTION
Switch to Delta E algorithm to factor in perception.
https://en.wikipedia.org/wiki/Color_difference#CIELAB_ΔE%2A

Currently using CIE76:

<p align="center"><img src="https://user-images.githubusercontent.com/114668551/225883064-22d52f30-164f-44e2-a552-ea1e17b11674.svg " alt="\Delta E_{ab}^{*}={\sqrt{(L_{2}^{*}-L_{1}^{*})^{2}+(a_{2}^{*}-a_{1}^{*})^{2}+(b_{2}^{*}-b_{1}^{*})^{2}}}"></img></p>

CIEDE2000 formula:

$$\Delta E_{00}^* = \sqrt{ \left(\frac{\Delta L'}{k_L S_L}\right)^2 + \left(\frac{\Delta C'}{k_C S_C}\right)^2 + \left(\frac{\Delta H'}{k_H S_H}\right)^2 + R_T \frac{\Delta C'}{k_C S_C}\frac{\Delta H'}{k_H S_H} }$$

Test cases:
- `#f25022` (Microsoft orange) - fourth result is now the brighter-looking `#ff5722` - before it was 3rd
- `#7fba00` (Microsoft green) - third result is now `#9ccc65` instead of `#aeea00`
- `#00a4ef` (Microsoft blue) - no change
- `#232150` (random Gitlab purple color):
  - Before: `#01579b`, `#1a237e`, `#283593`, `#0d47a1`, `#263238`
  - After: `#1a237e`, `#283593`, `#311b92`, `#4a148c`, `#4527a0`
